### PR TITLE
Add php82-simplexml dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk --no-cache --update \
     php82-pdo_sqlite \
     php82-phar \
     php82-session \
+    php82-simplexml \
     php82-xml \
     php82-tokenizer \
     php82-zip \


### PR DESCRIPTION
Closes #75 

Verified by installing `php82-simplexml` using the interactive console.
Haven't tried with built image yet, but it should work.